### PR TITLE
Create a component to store webpage state using dcc.Store

### DIFF
--- a/components/StoreState.py
+++ b/components/StoreState.py
@@ -1,0 +1,70 @@
+from dash import no_update, ctx, dcc
+from dash.dependencies import Input, Output, State, ALL
+import json
+
+class StoreState:
+    def __init__(self, store_type='session'):
+        """Initialize StoreState class and set the storage type for dcc.Store."""
+        self.store_type = store_type  # Set storage type
+
+    def get_store_component(self, store_id):
+        """Return the dcc.Store component using the specified storage type."""
+        return dcc.Store(id=store_id, storage_type=self.store_type)
+
+    @staticmethod
+    def save_state_to_store(store_data, key, value):
+        """Save data to dcc.Store."""
+        if store_data is None:
+            store_data = {}
+        store_data[key] = value
+        return store_data
+
+    @staticmethod
+    def load_state_from_store(store_data, key):
+        """Read data from dcc.Store."""
+        if store_data and key in store_data:
+            return store_data[key]
+        return None
+
+    def setup_dash_callbacks(self, app, store_id):
+        """Set up Dash callbacks to manage dcc.Store data, supporting multiple dynamic input components."""
+
+        @app.callback(
+            Output(store_id, 'data'),
+            Input({'type': 'dynamic-input', 'index': ALL}, 'value'),
+            State(store_id, 'data'),
+            prevent_initial_call=True
+        )
+        def save_data(input_values, store_data):
+            # Update storage if triggered by input component
+            if ctx.triggered:
+                for i, value in enumerate(input_values):
+                    if value is not None:
+                        key = f'input_{i}'
+                        store_data = StoreState.save_state_to_store(store_data, key, value)
+                return store_data
+            return no_update
+
+        @app.callback(
+            Output({'type': 'dynamic-input', 'index': ALL}, 'value'),
+            Input(store_id, 'modified_timestamp'),
+            State(store_id, 'data'),
+            prevent_initial_call=True
+        )
+        def load_data(modified_timestamp, store_data):
+            if modified_timestamp:
+                # Get the current number of dynamic input components
+                num_outputs = len(ctx.outputs_list)
+
+                # Initialize output list, default to using no_update
+                input_values = [no_update] * num_outputs
+
+                # Update existing data
+                if store_data:
+                    for i in range(num_outputs):
+                        input_values[i] = store_data.get(f'input_{i}', no_update)
+
+                return input_values
+
+            # If modified_timestamp is empty or invalid, return a list of no_update
+            return [no_update] * len(ctx.outputs_list)


### PR DESCRIPTION
### Configuration and Setup

1. Place the `StoreState.py` file into the `components` folder of your project.

2. Import the `StoreState` class in your code to utilize its functionalities:
`from components.StoreState import StoreState`

3. Create an instance of StoreState and set the storage type. It is recommended to use 'local', but 'session' can be chosen based on specific needs.
`store_state = StoreState(store_type='local')  # Set storage type to 'local' or 'session'`

4. Within the required component, set up the Store component using the get_store_component method:
`store_state.get_store_component('my-store')  # Configure the Store component`

5. Use the `setup_dash_callbacks` method to configure the callbacks for the app, ensuring correct connection with the Store component:
`store_state.setup_dash_callbacks(app, store_id='my-store')  # Set up callbacks`


### Testing and Demonstration
As shown in the image below, when use `store_type='local'`, data is stored in the local storage. You can clear the stored data using JavaScript code `localStorage.clear()`. The data remains even after refreshing or closing the browser.
![image](https://github.com/user-attachments/assets/a1ad685a-69b1-4d56-b466-db73599fe4ea)

As shown in the image below, when use `store_type='session'`, data is stored in the session storage. The data will be cleared when the tab is closed, but it remains when the tab is refreshed.
![image](https://github.com/user-attachments/assets/ca61ec64-b239-48b1-9fac-ed27662ed660)

#### Development Environment:
Dash version: 2.17.1
React version: 18.2.0
Python version: 3.12
Operating System: Windows 11