### PR TITLE
Add IP / SI Switcher

### DIFF
--- a/components/input_environmental_personal.py
+++ b/components/input_environmental_personal.py
@@ -1,12 +1,7 @@
 import dash_mantine_components as dmc
 from dash import html
 
-from utils.my_config_file import (
-    ModelInputsInfo,
-    Models,
-    convert_units,
-    ElementsIDs
-)
+from utils.my_config_file import ModelInputsInfo, Models, convert_units, ElementsIDs
 
 
 def input_environmental_personal(selected_model: str = "PMV_ashrae", units: str = "SI"):
@@ -34,7 +29,6 @@ def input_environmental_personal(selected_model: str = "PMV_ashrae", units: str 
     )
 
     inputs.append(unit_toggle)
-
 
     return html.Form(
         dmc.Paper(

--- a/components/input_environmental_personal.py
+++ b/components/input_environmental_personal.py
@@ -5,12 +5,12 @@ from utils.my_config_file import (
     ModelInputsInfo,
     Models,
     convert_units,
+    ElementsIDs
 )
 
 
 def input_environmental_personal(selected_model: str = "PMV_ashrae", units: str = "SI"):
     inputs = []
-
     model = Models[selected_model].value.inputs
     convert_units(model, units)
 
@@ -26,6 +26,15 @@ def input_environmental_personal(selected_model: str = "PMV_ashrae", units: str 
             id=values.id,
         )
         inputs.append(input_filed)
+
+    unit_toggle = dmc.Switch(
+        id=ElementsIDs.UNIT_TOGGLE.value,
+        label="IP Units" if units == "IP" else "SI Units",
+        checked=units == "IP",
+    )
+
+    inputs.append(unit_toggle)
+
 
     return html.Form(
         dmc.Paper(

--- a/pages/home.py
+++ b/pages/home.py
@@ -92,7 +92,7 @@ def update_inputs(selected_model, is_ip):
     if selected_model is None:
         return no_update
     units = "IP" if is_ip else "SI"
-    return input_environmental_personal(selected_model,units)
+    return input_environmental_personal(selected_model, units)
 
 
 @callback(

--- a/pages/home.py
+++ b/pages/home.py
@@ -85,12 +85,14 @@ layout = dmc.Stack(
 @callback(
     Output(ElementsIDs.INPUT_SECTION.value, "children"),
     Input(dd_model["id"], "value"),
+    Input(ElementsIDs.UNIT_TOGGLE.value, "checked"),
 )
-def update_inputs(selected_model):
+def update_inputs(selected_model, is_ip):
     # todo this should also receive as input the units
     if selected_model is None:
         return no_update
-    return input_environmental_personal(selected_model)
+    units = "IP" if is_ip else "SI"
+    return input_environmental_personal(selected_model,units)
 
 
 @callback(
@@ -106,7 +108,6 @@ def update_outputs(selected_model, form, form_content):
 
     # todo we should extract the input values from the form_content
     # todo we should also check the units
-
     # todo the following function should be moved outside the code
     def find_dict_with_key_value(d, key, value):
         if isinstance(d, dict):
@@ -144,6 +145,7 @@ def update_outputs(selected_model, form, form_content):
             form_content, "id", ElementsIDs.v_input.value
         )
         v = result_dict["value"]
+
         r_pmv = pmv_ppd(
             tdb=tdb,
             tr=tr,

--- a/utils/my_config_file.py
+++ b/utils/my_config_file.py
@@ -48,6 +48,8 @@ class ElementsIDs(Enum):
     PMV_ASHARE_Humidity_SELECTION = "id-pmv-ashrae-humidity-method"
     PMV_ASHARE_Metabolic_SELECTION = "id-pmv-ashrae-metabolic-method"
     PMV_ASHARE_Clothing_SELECTION = "id-pmv-ashrae-clothing-method"
+    UNIT_TOGGLE = "id-unit-toggle" # FOR IP / SI Unit system switch
+
 
 
 class Config(Enum):
@@ -166,31 +168,43 @@ class UnitConverter:
             return UnitConverter.fps_to_mps(value)
         return value
 
+    # @staticmethod
+    # def convert_range(value, from_unit, to_unit):
+    #     if from_unit == "°F" and to_unit == "°C":
+    #         return round((value - 32) * 5 / 9, 2)
+    #     if from_unit == "°C" and to_unit == "°F":
+    #         return round(value * 9 / 5 + 32, 2)
+    #     if from_unit == "m/s" and to_unit == "ft/s":
+    #         return round(value * 3.28084, 2)
+    #     elif from_unit == "ft/s" and to_unit == "m/s":
+    #         return round(value / 3.28084, 2)
+
 
 def convert_units(model_inputs, to_unit_system):
     for input_info in model_inputs:
         if to_unit_system == "IP":
             if input_info.unit == "°C":
-                input_info.value = UnitConverter.convert_value(
-                    input_info.value, "°C", "°F"
-                )
+                input_info.value = UnitConverter.convert_value(input_info.value, "°C", "°F")
+                input_info.min = UnitConverter.convert_value(input_info.min, "°C", "°F")
+                input_info.max = UnitConverter.convert_value(input_info.max, "°C", "°F")
                 input_info.unit = "°F"
             elif input_info.unit == "m/s":
-                input_info.value = UnitConverter.convert_value(
-                    input_info.value, "m/s", "ft/s"
-                )
+                input_info.value = UnitConverter.convert_value(input_info.value, "m/s", "ft/s")
+                input_info.min = UnitConverter.convert_value(input_info.min, "m/s", "ft/s")
+                input_info.max = UnitConverter.convert_value(input_info.max, "m/s", "ft/s")
                 input_info.unit = "ft/s"
         elif to_unit_system == "SI":
             if input_info.unit == "°F":
-                input_info.value = UnitConverter.convert_value(
-                    input_info.value, "°F", "°C"
-                )
+                input_info.value = UnitConverter.convert_value(input_info.value, "°F", "°C")
+                input_info.min = UnitConverter.convert_value(input_info.min, "°F", "°C")
+                input_info.max = UnitConverter.convert_value(input_info.max, "°F", "°C")
                 input_info.unit = "°C"
             elif input_info.unit == "ft/s":
-                input_info.value = UnitConverter.convert_value(
-                    input_info.value, "ft/s", "m/s"
-                )
+                input_info.value = UnitConverter.convert_value(input_info.value, "ft/s", "m/s")
+                input_info.min = UnitConverter.convert_value(input_info.min, "ft/s", "m/s")
+                input_info.max = UnitConverter.convert_value(input_info.max, "ft/s", "m/s")
                 input_info.unit = "m/s"
+    return model_inputs
 
 
 class ModelInputsInfo(BaseModel):

--- a/utils/my_config_file.py
+++ b/utils/my_config_file.py
@@ -48,8 +48,7 @@ class ElementsIDs(Enum):
     PMV_ASHARE_Humidity_SELECTION = "id-pmv-ashrae-humidity-method"
     PMV_ASHARE_Metabolic_SELECTION = "id-pmv-ashrae-metabolic-method"
     PMV_ASHARE_Clothing_SELECTION = "id-pmv-ashrae-clothing-method"
-    UNIT_TOGGLE = "id-unit-toggle" # FOR IP / SI Unit system switch
-
+    UNIT_TOGGLE = "id-unit-toggle"  # FOR IP / SI Unit system switch
 
 
 class Config(Enum):
@@ -168,41 +167,46 @@ class UnitConverter:
             return UnitConverter.fps_to_mps(value)
         return value
 
-    # @staticmethod
-    # def convert_range(value, from_unit, to_unit):
-    #     if from_unit == "°F" and to_unit == "°C":
-    #         return round((value - 32) * 5 / 9, 2)
-    #     if from_unit == "°C" and to_unit == "°F":
-    #         return round(value * 9 / 5 + 32, 2)
-    #     if from_unit == "m/s" and to_unit == "ft/s":
-    #         return round(value * 3.28084, 2)
-    #     elif from_unit == "ft/s" and to_unit == "m/s":
-    #         return round(value / 3.28084, 2)
-
 
 def convert_units(model_inputs, to_unit_system):
     for input_info in model_inputs:
         if to_unit_system == "IP":
             if input_info.unit == "°C":
-                input_info.value = UnitConverter.convert_value(input_info.value, "°C", "°F")
+                input_info.value = UnitConverter.convert_value(
+                    input_info.value, "°C", "°F"
+                )
                 input_info.min = UnitConverter.convert_value(input_info.min, "°C", "°F")
                 input_info.max = UnitConverter.convert_value(input_info.max, "°C", "°F")
                 input_info.unit = "°F"
             elif input_info.unit == "m/s":
-                input_info.value = UnitConverter.convert_value(input_info.value, "m/s", "ft/s")
-                input_info.min = UnitConverter.convert_value(input_info.min, "m/s", "ft/s")
-                input_info.max = UnitConverter.convert_value(input_info.max, "m/s", "ft/s")
+                input_info.value = UnitConverter.convert_value(
+                    input_info.value, "m/s", "ft/s"
+                )
+                input_info.min = UnitConverter.convert_value(
+                    input_info.min, "m/s", "ft/s"
+                )
+                input_info.max = UnitConverter.convert_value(
+                    input_info.max, "m/s", "ft/s"
+                )
                 input_info.unit = "ft/s"
         elif to_unit_system == "SI":
             if input_info.unit == "°F":
-                input_info.value = UnitConverter.convert_value(input_info.value, "°F", "°C")
+                input_info.value = UnitConverter.convert_value(
+                    input_info.value, "°F", "°C"
+                )
                 input_info.min = UnitConverter.convert_value(input_info.min, "°F", "°C")
                 input_info.max = UnitConverter.convert_value(input_info.max, "°F", "°C")
                 input_info.unit = "°C"
             elif input_info.unit == "ft/s":
-                input_info.value = UnitConverter.convert_value(input_info.value, "ft/s", "m/s")
-                input_info.min = UnitConverter.convert_value(input_info.min, "ft/s", "m/s")
-                input_info.max = UnitConverter.convert_value(input_info.max, "ft/s", "m/s")
+                input_info.value = UnitConverter.convert_value(
+                    input_info.value, "ft/s", "m/s"
+                )
+                input_info.min = UnitConverter.convert_value(
+                    input_info.min, "ft/s", "m/s"
+                )
+                input_info.max = UnitConverter.convert_value(
+                    input_info.max, "ft/s", "m/s"
+                )
                 input_info.unit = "m/s"
     return model_inputs
 


### PR DESCRIPTION
### IP / SI Switcher
## Description
The IP / SI witcher is the new button added at the bottom of the Inputs box. It provides methods to switch the units of user inputs between SI and IP. The range (maximum and minimum) will also automatically change by calling the static convert methods.

## Types of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Implementation
![image](https://github.com/user-attachments/assets/efde0302-1ae8-4ada-af50-9f614ed891c4)
unit_toggle has been added, and it checks the units while running.
![image](https://github.com/user-attachments/assets/724daf30-5ff9-4471-99cc-c4b1d8bc789c)

Both the user inputs value and the maximum and minimum will change while Units changes. The current State of unit can be seen from the text at the right of the switcher and also the text of inputs: the unit for Temperatures and Air Speed will switch from "°C" and "m/s"" to "°F" and "ft/s".
![image](https://github.com/user-attachments/assets/33282327-fad8-458a-ad44-01524a827980)
![image](https://github.com/user-attachments/assets/bf5f3f95-d539-4c06-b4fd-91589eb1fe1b)

## Checklists
- [ ] update for documentation
- [ ] todo for update_input()
- [ ] todo for update_output()
- [ ] Add switcher
- [ ] Convert for values, max, and min





