### PR TITLE
Custom ensemble

### DIFF
--- a/components/charts.py
+++ b/components/charts.py
@@ -14,6 +14,9 @@ from components.drop_down_inline import generate_dropdown_inline
 from utils.my_config_file import ElementsIDs, Models
 from utils.website_text import TextHome
 
+# Matplotlib GUI Error
+import matplotlib
+matplotlib.use('Agg')
 
 def chart_selector(selected_model: str):
     list_charts = deepcopy(Models[selected_model].value.charts)

--- a/components/footer.py
+++ b/components/footer.py
@@ -104,6 +104,7 @@ def my_footer():
                 ],
                 align="center",
                 bg="#0077c2",
+                w="100%",
             ),
             dmc.Grid(
                 children=[

--- a/components/input_environmental_personal.py
+++ b/components/input_environmental_personal.py
@@ -203,23 +203,6 @@ def input_environmental_personal(
     State("modal-simple", "opened"),
     prevent_initial_call=True,
 )
-# def modal_demo(nc1, nc2, nc3, nc4, opened):
-
-
-#     return not opened, float(nc1)
-
-
-# @callback(
-#     State(ElementsIDs.MODEL_SELECTION.value, "value"),
-#     State(ElementsIDs.UNIT_TOGGLE.value, "checked"),
-#     State(ElementsIDs.inputs_form.value, "children"),
-#     # todo this function should also listen to changes in the variables inputs
-# )
-# def update_outputs(_, selected_model, units_selection: str, form_content: dict):
-#     return display_results(selected_model, form_content, units_selection)
-
-
-
 
 def modal_demo(clo_value, nc_open, nc_close, nc_submit, opened):
 

--- a/components/input_environmental_personal.py
+++ b/components/input_environmental_personal.py
@@ -195,7 +195,7 @@ def input_environmental_personal(
 # Custom Ensemble
 @callback(
     Output("modal-simple", "opened"),
-    Output("id-clo-input","value"),
+    Output(ElementsIDs.clo_input.value,"value"),
     Input("modal-clo-value","value"),
     Input("modal-demo-button", "n_clicks"),
     Input("modal-close-button", "n_clicks"),

--- a/components/input_environmental_personal.py
+++ b/components/input_environmental_personal.py
@@ -8,7 +8,8 @@ from utils.my_config_file import (
     ElementsIDs,
     UnitSystem,
 )
-
+import dash
+from components.show_results import display_results
 
 def modal_custom_ensemble():
     return dmc.Modal(
@@ -21,41 +22,96 @@ def modal_custom_ensemble():
                     dmc.Text(
                         "Select all the garments you want to include in the ensemble"
                     ),
-                    dmc.MultiSelect(
+                    dmc.Select(
+                        id="modal-clo-value",
                         data=[
                             {
                                 "group": "Underwear",
                                 "items": [
-                                    {"value": "React", "label": "React"},
-                                    {"value": "Angular", "label": "Angular"},
+                                    {"value": "0.01_Bra", "label": "Bra"},
+                                    {"value": "0.03", "label": "Women's underwear"},
+                                    {"value": "0.04", "label": "Men's underwear"},
+                                    {"value": "0.14_Half_slip", "label": "Half slip"},
+                                    {"value": "0.15_Long_underwear_bottoms","label": "Long underwear bottoms"},
+                                    {"value": "0.16","label": "Full slip"},
+                                    {"value": "0.20_Long_underwear","label": "Long underwear top"},
                                 ],
                             },
                             {
                                 "group": "Tops",
                                 "items": [
                                     # todo change these values
-                                    {"value": "Svelte", "label": "Svelte"},
-                                    {"value": "Vue", "label": "Vue"},
+                                    {"value": "0.08_T_shirt","label": "T-shirt"},
+                                    {"value": "0.12","label": "Sleeveless scoop-neck blouse"},
+                                    {"value": "0.17","label": "Short-sleeve knit shirt"},
+                                    {"value": "0.10_Sleevelss_vest_thin","label": "Sleeveless vest (thin)"},
+                                    {"value": "0.17_Sleevelss_vest_thick","label": "Sleeveless vest (thick)"},
+                                    {"value": "0.18","label": "Sleeveless short gown (thin)"},
+                                    {"value": "0.19","label": "Short-sleeve dress shirt"},
+                                    {"value": "0.20_Sleevelss_long_gown_thin","label": "Sleeveless long gown (thin)"},
+                                    {"value": "0.25_Long_sleeve_dress_shirt","label": "Long-sleeve dress shirt"},
+                                    {"value": "0.34","label": "Long-sleeve flannel shirt"},
+                                    {"value": "0.34_Long_sleeve_sweat_shirt","label": "Long-sleeve sweat shirt"},
+                                    {"value": "0.31","label": "Short-sleeve hospital gown"},
+                                    {"value": "0.34_Short_sleeve_short_robe_thin","label": "Short-sleeve short robe (thin)"},
+                                    {"value": "0.42_Short_sleeve_pajamas","label": "Short-sleeve pajamas"},
+                                    {"value": "0.46","label": "Short-sleeve long gown"},
+                                    {"value": "0.48","label": "Short-sleeve short wrap robe (thick)"},
+                                    {"value": "0.57","label": "Short-sleeve pajamas (thick)"},
+                                    {"value": "0.69","label": "Short-sleeve long wrap robe (thick)"},
+                                    {"value": "0.30","label": "Overalls"},
+                                    {"value": "0.49","label": "Coveralls"},
+                                    {"value": "0.23","label": "Sleeveless, scoop-neck shirt (thin)"},
+                                    {"value": "0.27","label": "Sleeveless, scoop-neck shirt (thick)"},   
+                                    {"value": "0.13","label": "Sleeveless vest (thin)"},
+                                    {"value": "0.22","label": "Sleeveless vest (thick)"},
+                                    {"value": "0.25","label": "Long sleeve shirt (thin)"},
+                                    {"value": "0.36_Long_sleeve_shirt_thick","label": "Long sleeve shirt (thick)"},
+                                    {"value": "0.36","label": "Single-breasted coat (thin)"},
+                                    {"value": "0.44","label": "Single-breasted coat (thick)"},
+                                    {"value": "0.42","label": "Double-breasted coat (thin)"},
+                                    {"value": "0.48_Double_breasted_coat_thick","label": "Double-breasted coat (thick)"},
                                 ],
                             },
                             {
                                 "group": "Trousers",
                                 "items": [
-                                    {
-                                        "value": "Thin trousers",
-                                        "label": "Thin trousers",
-                                    },
-                                    {
-                                        "value": "Thick trousers",
-                                        "label": "Thick trousers",
-                                    },
+                                    {"value": "0.06_Short_shorts","label": "Short shorts"},
+                                    {"value": "0.08","label": "Walking shorts"},
+                                    {"value": "0.14","label": "Thin skirt"},
+                                    {"value": "0.23_Thick_skirt","label": "Thick skirt"},
+                                    {"value": "0.15_Thin_trousers","label": "Thin trousers"},
+                                    {"value": "0.24","label": "Thick trousers"},
+                                    {"value": "0.28","label": "Sweatpants"},
+                                    {"value": "0.33","label": "Long-sleeve shirtdress (thin)"},
+                                    {"value": "0.47","label": "Long-sleeve shirtdress (thick)"},
+                                    {"value": "0.29","label": "Short-sleeve shirtdress"},
                                 ],
+                            },
+                            {
+                                "group": "Socks",
+                                "items": [
+                                    {"value": "0.02_Ankle_socks","label": "Ankle socks"},
+                                    {"value": "0.02_Panty_hose","label": "Panty hose"},
+                                    {"value": "0.03_Claf_length_socks","label": "Calf length socks"},
+                                    {"value": "0.06","label": "Knee socks (thick)"},
+                                ]
                             },
                             {
                                 "group": "Shoes",
                                 "items": [
-                                    {"value": "Boots", "label": "Boots"},
-                                    {"value": "Flip flops", "label": "Flip flops"},
+                                    {"value": "0.02", "label": "Shoes or sandals"},
+                                    {"value": "0.03_Slippers", "label": "Slippers"},
+                                    {"value": "0.10_Boots", "label": "Boots"},
+                                ],
+                            },
+                            {
+                                "group": "Chair",
+                                "items": [
+                                    {"value": "0.00", "label": "Metal chair"},
+                                    {"value": "0.01", "label": "Wooden stool"},
+                                    {"value": "0.10", "label": "Standard office chair"},
+                                    {"value": "0.15", "label": "Executive chair"},
                                 ],
                             },
                         ],
@@ -136,14 +192,43 @@ def input_environmental_personal(
         p="md",
     )
 
-
+# Custom Ensemble
 @callback(
     Output("modal-simple", "opened"),
+    Output("id-clo-input","value"),
+    Input("modal-clo-value","value"),
     Input("modal-demo-button", "n_clicks"),
     Input("modal-close-button", "n_clicks"),
     Input("modal-submit-button", "n_clicks"),
     State("modal-simple", "opened"),
     prevent_initial_call=True,
 )
-def modal_demo(nc1, nc2, nc3, opened):
-    return not opened
+# def modal_demo(nc1, nc2, nc3, nc4, opened):
+
+
+#     return not opened, float(nc1)
+
+
+# @callback(
+#     State(ElementsIDs.MODEL_SELECTION.value, "value"),
+#     State(ElementsIDs.UNIT_TOGGLE.value, "checked"),
+#     State(ElementsIDs.inputs_form.value, "children"),
+#     # todo this function should also listen to changes in the variables inputs
+# )
+# def update_outputs(_, selected_model, units_selection: str, form_content: dict):
+#     return display_results(selected_model, form_content, units_selection)
+
+
+
+
+def modal_demo(clo_value, nc_open, nc_close, nc_submit, opened):
+
+    ctx = dash.callback_context.triggered_id
+
+    if ctx == "modal-demo-button":
+        return True, dash.no_update
+    
+    if ctx in ["modal-close-button", "modal-submit-button"]:
+        return False, float(str(clo_value)[:4]) if ctx == "modal-submit-button" and clo_value else dash.no_update
+
+    return opened, dash.no_update

--- a/pages/home.py
+++ b/pages/home.py
@@ -113,6 +113,7 @@ def update_note_model(selected_model):
 @callback(
     Output(ElementsIDs.CHART_CONTAINER.value, "children"),
     Input(ElementsIDs.inputs_form.value, "n_clicks"),
+    Input(ElementsIDs.clo_input.value,"value"),
     Input(ElementsIDs.chart_selected.value, "value"),
     State(ElementsIDs.MODEL_SELECTION.value, "value"),
     State(ElementsIDs.UNIT_TOGGLE.value, "checked"),
@@ -120,6 +121,7 @@ def update_note_model(selected_model):
 )
 def update_chart(
     _,
+    clo_value,
     chart_selected: str,
     selected_model: str,
     units_selection: str,
@@ -171,10 +173,12 @@ def update_chart(
 @callback(
     Output(ElementsIDs.RESULTS_SECTION.value, "children"),
     Input(ElementsIDs.inputs_form.value, "n_clicks"),
+    Input(ElementsIDs.clo_input.value,"value"),
     State(ElementsIDs.MODEL_SELECTION.value, "value"),
     State(ElementsIDs.UNIT_TOGGLE.value, "checked"),
     State(ElementsIDs.inputs_form.value, "children"),
     # todo this function should also listen to changes in the variables inputs
 )
-def update_outputs(_, selected_model, units_selection: str, form_content: dict):
+def update_outputs(_, clo_value, selected_model, units_selection: str, form_content: dict):
+    
     return display_results(selected_model, form_content, units_selection)


### PR DESCRIPTION
### Custom ensemble implementation
## Description
Implement the Custom Ensemble button function values updated Clothingf Level from the old version of the CBE Thermal comfort tool, and in this tool, this function shoule be a single-select dropdown，copy all the value from the previous tool and classify them.

## Types of change
- [x] Fix the matplotlib error
- [x] Fix the Footer display error
- [x] Implement the custom ensemble function

## Implementation

### Since the Select component in DMC does not support duplicate options, I have two solutions here:

First, modify the suffix, such as "0.17_T-shirt". This method allows the conversion to a float by selecting the first part of the string. Currently, I’m using the first method, but this can be revised in future versions.
![image](https://github.com/user-attachments/assets/64494837-9dbb-4913-b197-eafebaa4dd9a)

The another solution is merge options with the same value, for example, "0.17", "label": short-sleeve knit shirt, sleeveless vest (thick). However, since there may be the same value across different groups, merging them could change their categorization.

Change clothing level value will update the  display result and charts:
![image](https://github.com/user-attachments/assets/01b7163d-b858-4897-ae51-8fffbdf2f563)



