### PR TITLE
add the chart and annotation of the psy air temp in function selectio…

### DIFF
--- a/pages/home.py
+++ b/pages/home.py
@@ -2,7 +2,7 @@ import dash
 import dash_mantine_components as dmc
 from dash import html, callback, Output, Input, no_update, State, ctx, dcc
 
-from components.charts import t_rh_pmv, chart_selector, adaptive_en_chart
+from components.charts import t_rh_pmv, chart_selector, adaptive_en_chart, psychrometric_ashrae
 from components.dropdowns import (
     model_selection,
 )
@@ -225,6 +225,27 @@ def update_chart(inputs: dict, function_selection: str):
         ]
     )
     image = go.Figure()
+
+     #add 'if' condition to identify whether user want to enter the compare.
+    if chart_selected == Charts.psychrometric.value.name:
+        if (
+            selected_model == Models.PMV_ashrae.name
+            and function_selection == Functionalities.Compare.value
+        ):
+            image = psychrometric_ashrae(
+                inputs=inputs,
+                model="ashrae",
+                function_selection=function_selection,
+                units=units,
+            )
+
+            image = psychrometric_ashrae(
+                inputs=inputs,
+                model="ashrae",
+                function_selection=function_selection,
+                units=units,
+            )
+
 
     if chart_selected == Charts.t_rh.value.name:
         if (


### PR DESCRIPTION
The chart and annotation including the si and ip modes can be displayed correctly. The filled area (blue and grey) and red point(input1) with purple point(input2) can be moved based on the user selection on those six attributes.

psychrometric air temperature

- [ ]  added "psychrometric air temperature" charts into the compare of function selection in the project, and combined 'PMV-ASHREA' and 'PMV EN' into one function to simplify the code into the compare of function selection in the project.

- [ ]  The attributes including 'Relative humidity', 'Dry-bulb Temperature' and comfort level can be shown in the compare of function selection

- [ ]  There are two filled areas blue and grey that are on input 1 and 2 respectively.

 

- [ ] If one of the points is outside the comfort area, the warning "not comply with the one standard" can be shown on the chart.

 

- [ ] The relevant exchanges including x-axis, input box, and the returned value on the top of the chart can be displayed on two modes 'si' and 'ip'

 

- [ ] The relevant value in Annotation can be shown on the two modes 'si' and 'ip'

The string value of "complies with ASHRAE Standard 55-2023" can be adjusted by user changing the input of temperature or comfort area:
units=si:
![image](https://github.com/user-attachments/assets/a27036af-72db-4509-92e2-b58133a28c9c)
![image](https://github.com/user-attachments/assets/6c042750-19c0-436c-9754-3871b83b89fd)
![image](https://github.com/user-attachments/assets/5870f0b0-9493-4002-b0f1-a365968646c5)

units=ip:
![image](https://github.com/user-attachments/assets/36c235c5-2670-4b86-93d2-d6b8a5886ce4)
![image](https://github.com/user-attachments/assets/2843b354-911b-4da7-95ae-fed3289b0ded)
![image](https://github.com/user-attachments/assets/17425678-7ea4-4ea2-90d4-2d2c415386d5)

The last two parameters in the annotation display can be shown normally by using correct calculation function.
unit=si:
![image](https://github.com/user-attachments/assets/a027fe05-ecef-4f44-8c92-cc2e6d88b7d3)

unit=ip:
![image](https://github.com/user-attachments/assets/90671c57-cd85-492a-a918-3bd9e9b03653)
