### PR TITLE
Compare - psychrometrics air temperature 

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,7 +84,7 @@ app.layout = dmc.MantineProvider(
 if __name__ == "__main__":
     app.run_server(
         debug=Config.DEBUG.value,
-        host="0.0.0.0",
+        host="127.0.0.1",
         port=os.environ.get("PORT_APP", 9090),
         processes=1,
         threaded=True,

--- a/components/charts.py
+++ b/components/charts.py
@@ -1,13 +1,10 @@
 import math
 import numpy as np
-<<<<<<< HEAD
-import pandas as pd
-from pythermalcomfort.models import pmv
-=======
+
 import pandas as pd 
 from pythermalcomfort.psychrometrics import t_o, psy_ta_rh
 from pythermalcomfort.models import pmv, cooling_effect, adaptive_en, adaptive_ashrae, two_nodes
->>>>>>> comfort-dash/development
+
 from pythermalcomfort.utilities import v_relative, clo_dynamic, units_converter
 from scipy import optimize
 
@@ -22,14 +19,7 @@ from utils.my_config_file import (
     UnitConverter,
 )
 from utils.website_text import TextHome
-<<<<<<< HEAD
-import matplotlib
-from pythermalcomfort.models import adaptive_en
-from pythermalcomfort.psychrometrics import psy_ta_rh, t_o
 
-matplotlib.use("Agg")
-=======
->>>>>>> comfort-dash/development
 
 import plotly.graph_objects as go
 from dash import dcc
@@ -398,87 +388,9 @@ def t_rh_pmv(
 
     return fig
 
-<<<<<<< HEAD
-# function in pmv_ppd()
-def _pmv_ppd_optimized(tdb, tr, vr, rh, met, clo, wme=0):
-    pa = rh * 10 * np.exp(16.6536 - 4030.183 / (tdb + 235))
+#<<<<<<< HEAD
 
-    icl = 0.155 * clo  # thermal insulation of the clothing in M2K/W
-    m = met * 58.15  # metabolic rate in W/M2
-    w = wme * 58.15  # external work in W/M2
-    mw = m - w  # internal heat production in the human body
-    # calculation of the clothing area factor
-    if icl <= 0.078:
-        f_cl = 1 + (1.29 * icl)  # ratio of surface clothed body over nude body
-    else:
-        f_cl = 1.05 + (0.645 * icl)
-
-    # heat transfer coefficient by forced convection
-    hcf = 12.1 * np.sqrt(vr)
-    hc = hcf  # initialize variable
-    taa = tdb + 273
-    tra = tr + 273
-    t_cla = taa + (35.5 - tdb) / (3.5 * icl + 0.1)
-
-    p1 = icl * f_cl
-    p2 = p1 * 3.96
-    p3 = p1 * 100
-    p4 = p1 * taa
-    p5 = (308.7 - 0.028 * mw) + (p2 * (tra / 100.0) ** 4)
-    xn = t_cla / 100
-    xf = t_cla / 50
-    eps = 0.00015
-
-    n = 0
-    while np.abs(xn - xf) > eps:
-        xf = (xf + xn) / 2
-        hcn = 2.38 * np.abs(100.0 * xf - taa) ** 0.25
-        if hcf > hcn:
-            hc = hcf
-        else:
-            hc = hcn
-        xn = (p5 + p4 * hc - p2 * xf**4) / (100 + p3 * hc)
-        n += 1
-        if n > 150:
-            raise StopIteration("Max iterations exceeded")
-
-    tcl = 100 * xn - 273
-
-    # heat loss diff. through skin
-    hl1 = 3.05 * 0.001 * (5733 - (6.99 * mw) - pa)
-    # heat loss by sweating
-    if mw > 58.15:
-        hl2 = 0.42 * (mw - 58.15)
-    else:
-        hl2 = 0
-    # latent respiration heat loss
-    hl3 = 1.7 * 0.00001 * m * (5867 - pa)
-    # dry respiration heat loss
-    hl4 = 0.0014 * m * (34 - tdb)
-    # heat loss by radiation
-    hl5 = 3.96 * f_cl * (xn**4 - (tra / 100.0) ** 4)
-    # heat loss by convection
-    hl6 = f_cl * hc * (tcl - tdb)
-
-    ts = 0.303 * np.exp(-0.036 * m) + 0.028
-    _pmv = ts * (mw - hl1 - hl2 - hl3 - hl4 - hl5 - hl6)
-
-    return _pmv
-
-def calculate_tdb(t_db_x, t_r, v_r, r_h, met, clo_d, pmv_y):
-    return (
-        _pmv_ppd_optimized(tdb=t_db_x, tr=t_r, vr=v_r, rh=r_h, met=met, clo=clo_d)
-        - pmv_y
-    )
-
-# Psychrometric(air temperature) of ASHRAE
-def psychrometric_ashrae(
-    inputs: dict = None,
-    model: str = "iso",
-    function_selection: str = Functionalities.Default,
-    units: str = "SI",
-    
-=======
+#=======
 
 # Thermal heat losses vs. air temperature of ASHRAE
 def get_heat_losses(inputs: dict = None, model: str = "ashrae", units: str = "SI"):
@@ -1174,7 +1086,7 @@ def psy_pmv(
     inputs: dict = None,
     model: str = "ASHRAE",
     units: str = "SI",
->>>>>>> comfort-dash/development
+
 ):
 
     p_tdb = float(inputs[ElementsIDs.t_db_input.value])
@@ -1184,11 +1096,9 @@ def psy_pmv(
             v=inputs[ElementsIDs.v_input.value], met=inputs[ElementsIDs.met_input.value]
         )
     )
-<<<<<<< HEAD
-    rh = float(inputs[ElementsIDs.rh_input.value])
-=======
+
     p_rh = float(inputs[ElementsIDs.rh_input.value])
->>>>>>> comfort-dash/development
+
     met = float(inputs[ElementsIDs.met_input.value])
     clo = float(
         clo_dynamic(  # Ensure clo is scalar
@@ -1206,223 +1116,7 @@ def psy_pmv(
 
     traces = []
 
-<<<<<<< HEAD
-    # blue area
 
-    rh_values = np.arange(0, 110, 10)
-    tdb_guess = 22
-    pmv_list = [-0.5, 0.5]
-    tdb_array = np.zeros((len(pmv_list), len(rh_values)))
-    for j, pmv_value in enumerate(pmv_list):
-        for i, rh_value in enumerate(rh_values):
-            solution = fsolve(
-                lambda x: calculate_tdb(
-                    t_db_x=x,
-                    t_r=tr,
-                    v_r=vr,
-                    r_h=rh_value,
-                    met=met,
-                    clo_d=clo,
-                    pmv_y=pmv_value,
-                ),
-                tdb_guess,
-            )
-            tdb_solution = round(solution[0], 1)
-            tdb_guess = tdb_solution
-            tdb_array[j, i] = float(tdb_solution)
-
-    # calculate hr
-
-    lower_upper_tdb = np.append(tdb_array[0], tdb_array[1][::-1])
-    lower_upper_tdb = [
-        round(float(value), 1) for value in lower_upper_tdb.tolist()
-    ]  # convert to list & round to 1 decimal
-
-    rh_list = np.append(np.arange(0, 110, 10), np.arange(100, -1, -10))
-
-
-    # define
-    lower_upper_hr = []
-    for i in range(len(rh_list)):
-        lower_upper_hr.append(
-            psy_ta_rh(tdb=lower_upper_tdb[i], rh=rh_list[i])["hr"] * 1000
-        )
-
-    lower_upper_hr = [
-        round(float(value), 1) for value in lower_upper_hr
-    ]  # convert to list & round to 1 decimal
-
-    if units == UnitSystem.IP.value:
-        lower_upper_tdb = list(
-            map(
-                lambda x: round(float(units_converter(tmp=x, from_units="si")[0]), 1),
-                lower_upper_tdb,
-            )
-        )
-    
-    # grey area
-    if model == "ashrae" and function_selection == Functionalities.Compare.value:
-            
-            met_2, clo_2, tr_2, t_db_2, v_2, rh_2 = compare_get_inputs(inputs)
-            
-            print("Type of met_2:", type(met_2), "Value:", met_2)
-            print("Type of clo_2:", type(clo_2), "Value:", clo_2)
-            print("Type of tr_2:", type(tr_2), "Value:", tr_2)
-            print("Type of t_db_2:", type(t_db_2), "Value:", t_db_2)
-            print("Type of v_2:", type(v_2), "Value:", v_2)
-            print("Type of rh_2:", type(rh_2), "Value:", rh_2)
-
-            clo_d_compare = clo_dynamic(clo_2, met_2)
-            vr_compare = v_relative(v_2, met_2)
-            
-           
-            vr_2 = vr_compare
-            clo_2 = clo_d_compare
-             # save original values for plotting
-            
-            
-            if units == UnitSystem.IP.value:
-
-                t_db_2 = round(float(units_converter(tdb=t_db_2)[0]), 1)
-                tr_2 = round(float(units_converter(tr=tr_2)[0]), 1)
-                vr_2 = round(float(units_converter(vr=vr_2)[0]), 1)
-                print("Type of t_db_2:", type(t_db_2), "Value:", t_db_2)
-                print("Type of tr_2:", type(tr_2), "Value:", tr_2)
-                print("Type of vr_2:", type(vr_2), "Value:", vr_2)
-               
-            else:
-                t_db_2 = t_db_2
-            
-            
-                
-            print("Type of t_db_2:", type(t_db_2), "Value:", t_db_2)
-            print("Type of tr_2:", type(tr_2), "Value:", tr_2)
-            print("Type of vr_2:", type(vr_2), "Value:", vr_2)
-            
-        
-           
-            traces = []
-    
-    
-            
-            rh_values_2 = np.arange(0, 110, 10)
-            tdb_guess_2 = 22
-            pmv_list_2 = [-0.5, 0.5]
-            tdb_array_2 = np.zeros((len(pmv_list_2), len(rh_values_2)))
-            for j, pmv_value in enumerate(pmv_list_2):
-                for i, rh_value in enumerate(rh_values_2):
-                    solution_2 = fsolve(
-                        lambda x2: calculate_tdb(
-                            t_db_x=x2,
-                            t_r=tr_2,
-                            v_r=vr_2,
-                            r_h=rh_value,
-                            met=met_2,
-                            clo_d=clo_2,
-                            pmv_y=pmv_value,
-                        ),
-                        tdb_guess_2,
-                    )
-                    tdb_solution_2 = round(solution_2[0], 1)
-                    tdb_guess_2 = tdb_solution_2
-                    tdb_array_2[j, i] = float(tdb_solution_2)
-        
-            # calculate hr
-           
-            lower_upper_tdb_2 = np.append(tdb_array_2[0], tdb_array_2[1][::-1])
-            lower_upper_tdb_2 = [
-                round(float(value), 1) for value in lower_upper_tdb_2.tolist()
-            ]  # convert to list & round to 1 decimal
-        
-            rh_list_2 = np.append(np.arange(0, 110, 10), np.arange(100, -1, -10))
-        
-        
-            # define
-            lower_upper_hr_2 = []
-            for i in range(len(rh_list_2)):
-                lower_upper_hr_2.append(
-                    psy_ta_rh(tdb=lower_upper_tdb_2[i], rh=rh_list_2[i])["hr"] * 1000
-                )
-        
-            lower_upper_hr_2 = [
-                round(float(value), 1) for value in lower_upper_hr_2
-            ]  # convert to list & round to 1 decimal
-        
-            if units == UnitSystem.IP.value:
-                lower_upper_tdb_2 = list(
-                    map(
-                        lambda x2: round(float(units_converter(tmp=x2, from_units="si")[0]), 1),
-                        lower_upper_tdb_2,
-                    )
-                )
-        
-            traces.append(
-                go.Scatter(
-                    x=lower_upper_tdb_2,
-                    y=lower_upper_hr_2,
-                    mode="lines",
-                    line=dict(color="rgba(0,0,0,0)"),
-                    fill="toself",
-                    fillcolor="rgba(200, 200, 200, 0.7)",
-                    showlegend=False,
-                    hoverinfo="none",
-                )
-            )
-        
-            # current point
-            # Red point
-        
-            psy_results = psy_ta_rh(t_db_2, rh_2)
-            hr_2 = round(float(psy_results["hr"]) * 1000, 1)
-            t_wb_2 = round(float(psy_results["t_wb"]), 1)
-            t_dp_2 = round(float(psy_results["t_dp"]), 1)
-            h = round(float(psy_results["h"]) / 1000, 1)
-        
-            if units == UnitSystem.IP.value:
-                t_wb_2 = round(float(units_converter(tmp=t_wb_2, from_units="si")[0]), 1)
-                t_dp_2 = round(float(units_converter(tmp=t_dp_2, from_units="si")[0]), 1)
-                h = round(float(h / 2.326), 1)  # kJ/kg => btu/lb
-                t_db_2 = (t_db_2 * 9/5) + 32
-            
-            print("Type of hr_2:", type(hr_2), "Value:", hr_2)
-            print("Type of t_wb_2:", type(t_wb_2), "Value:", t_wb_2)
-            print("Type of t_dp_2:", type(t_dp_2), "Value:", t_dp_2)
-            print("Type of h:", type(h), "Value:", h)
-            print("Type of t_db_2:", type(t_db_2), "Value:", t_db_2)
-            
-            
-            traces.append(
-                go.Scatter(
-                    x=[t_db_2],
-                    y=[hr_2],
-                    mode="markers",
-                    marker=dict(
-                        color="purple",
-                        size=6,
-                    ),
-                    showlegend=False,
-                )
-            )
-
-
-    traces.append(
-        go.Scatter(
-            x=lower_upper_tdb,
-            y=lower_upper_hr,
-            mode="lines",
-            line=dict(color="rgba(0,0,0,0)"),
-            fill="toself",
-            fillcolor="rgba(59, 189, 237, 0.7)",
-            showlegend=False,
-            hoverinfo="none",
-        )
-    )
-
-    # current point
-    # Red point
-
-    psy_results = psy_ta_rh(tdb, rh)
-=======
     # if model is PMV-ASHRAE plot blue area, else plot green areas
     rh_values = np.arange(0, 110, 10)
     if model == "ASHRAE":
@@ -1641,7 +1335,7 @@ def psy_pmv(
     # current point
     # Red point
     psy_results = psy_ta_rh(tdb, p_rh)
->>>>>>> comfort-dash/development
+
     hr = round(float(psy_results["hr"]) * 1000, 1)
     t_wb = round(float(psy_results["t_wb"]), 1)
     t_dp = round(float(psy_results["t_dp"]), 1)
@@ -1650,11 +1344,9 @@ def psy_pmv(
     if units == UnitSystem.IP.value:
         t_wb = round(float(units_converter(tmp=t_wb, from_units="si")[0]), 1)
         t_dp = round(float(units_converter(tmp=t_dp, from_units="si")[0]), 1)
-<<<<<<< HEAD
-        h = round(float(h / 2326), 1)  # kJ/kg => btu/lb
-=======
+
         h = round(float(h / 2.326), 1)  # kJ/kg => btu/lb
->>>>>>> comfort-dash/development
+
         tdb = p_tdb
 
     traces.append(
@@ -1667,18 +1359,12 @@ def psy_pmv(
                 size=6,
             ),
             showlegend=False,
-<<<<<<< HEAD
-        )
-    )
 
-       
-
-=======
             hoverinfo="skip",
         )
     )
 
->>>>>>> comfort-dash/development
+
     # lines
 
     rh_list = np.arange(0, 110, 10, dtype=float).tolist()
@@ -1702,28 +1388,15 @@ def psy_pmv(
             y=hr_list,
             mode="lines",
             line=dict(color="grey", width=1),
-<<<<<<< HEAD
-            hoverinfo="x+y",
-=======
+
             hoverinfo="skip",
->>>>>>> comfort-dash/development
+
             name=f"{rh}% RH",
             showlegend=False,
         )
         traces.append(trace)
 
-<<<<<<< HEAD
-    
-    
-    tdb = inputs[ElementsIDs.t_db_input.value]
-    rh = inputs[ElementsIDs.rh_input.value]
-    tr = inputs[ElementsIDs.t_r_input.value]
 
-   
-    
-
-    
-=======
     # add transparent grid
     x_range = (
         np.linspace(10, 36, 100)
@@ -1744,13 +1417,489 @@ def psy_pmv(
             showlegend=False,
         )
     )
->>>>>>> comfort-dash/development
+
 
     if units == UnitSystem.SI.value:
         temperature_unit = "°C"
         hr_unit = "g<sub>w</sub>/kg<sub>da</sub>"
         h_unit = "kJ/kg"
-<<<<<<< HEAD
+
+    else:
+        temperature_unit = "°F"
+        hr_unit = "lb<sub>w</sub>/klb<sub>da</sub>"
+        h_unit = "btu/lb"
+
+    # layout
+    layout = go.Layout(
+        hovermode="closest",
+
+        xaxis=dict(
+            title=(
+                "Dry-bulb Temperature [°C]"
+                if units == UnitSystem.SI.value
+                else "operative Temperature [°F]"
+            ),
+            range=[10, 36] if units == UnitSystem.SI.value else [50, 96.8],
+            dtick=2,
+            showgrid=True,
+            showline=True,
+            linewidth=1.5,
+            linecolor="lightgrey",
+        ),
+        yaxis=dict(
+            title=(
+                "Humidity Ratio [g<sub>w</sub>/kg<sub>da</sub>]"
+                if units == UnitSystem.SI.value
+
+                else "Humidity ratio [lb<sub>w</sub>/klb<sub>da</sub>]"
+
+            ),
+            range=[0, 30],
+            dtick=5,
+            showgrid=True,
+            showline=True,
+            linewidth=1.5,
+            linecolor="lightgrey",
+            side="right",
+        ),
+        annotations=[
+            dict(
+
+                x=14 if units == UnitSystem.SI.value else 57.2,
+                y=25,
+                xref="x",
+                yref="y",
+                text=(
+                    f"t<sub>db</sub>: {tdb:.1f} {temperature_unit}<br>"
+                    f"rh: {p_rh:.1f} %<br>"
+                    f"W<sub>a</sub>: {hr} {hr_unit}<br>"
+                    f"t<sub>wb</sub>: {t_wb} {temperature_unit}<br>"
+                    f"t<sub>dp</sub>: {t_dp} {temperature_unit}<br>"
+                    f"h: {h} {h_unit}"
+
+                ),
+                showarrow=False,
+                align="left",
+                bgcolor="rgba(255,255,255,0.8)",
+                bordercolor="rgba(0,0,0,0)",
+
+                font=dict(size=14),
+
+            )
+        ],
+        showlegend=True,
+        plot_bgcolor="white",
+
+        margin=dict(l=0, t=10),
+        height=500,
+        width=680,
+    )
+
+    fig = go.Figure(data=traces, layout=layout)
+    return fig
+
+
+# function in pmv_ppd()
+def _pmv_ppd_optimized(tdb, tr, vr, rh, met, clo, wme=0):
+    pa = rh * 10 * np.exp(16.6536 - 4030.183 / (tdb + 235))
+
+    icl = 0.155 * clo  # thermal insulation of the clothing in M2K/W
+    m = met * 58.15  # metabolic rate in W/M2
+    w = wme * 58.15  # external work in W/M2
+    mw = m - w  # internal heat production in the human body
+    # calculation of the clothing area factor
+    if icl <= 0.078:
+        f_cl = 1 + (1.29 * icl)  # ratio of surface clothed body over nude body
+    else:
+        f_cl = 1.05 + (0.645 * icl)
+
+    # heat transfer coefficient by forced convection
+    hcf = 12.1 * np.sqrt(vr)
+    hc = hcf  # initialize variable
+    taa = tdb + 273
+    tra = tr + 273
+    t_cla = taa + (35.5 - tdb) / (3.5 * icl + 0.1)
+
+    p1 = icl * f_cl
+    p2 = p1 * 3.96
+    p3 = p1 * 100
+    p4 = p1 * taa
+    p5 = (308.7 - 0.028 * mw) + (p2 * (tra / 100.0) ** 4)
+    xn = t_cla / 100
+    xf = t_cla / 50
+    eps = 0.00015
+
+    n = 0
+    while np.abs(xn - xf) > eps:
+        xf = (xf + xn) / 2
+        hcn = 2.38 * np.abs(100.0 * xf - taa) ** 0.25
+        if hcf > hcn:
+            hc = hcf
+        else:
+            hc = hcn
+        xn = (p5 + p4 * hc - p2 * xf**4) / (100 + p3 * hc)
+        n += 1
+        if n > 150:
+            raise StopIteration("Max iterations exceeded")
+
+    tcl = 100 * xn - 273
+
+    # heat loss diff. through skin
+    hl1 = 3.05 * 0.001 * (5733 - (6.99 * mw) - pa)
+    # heat loss by sweating
+    if mw > 58.15:
+        hl2 = 0.42 * (mw - 58.15)
+    else:
+        hl2 = 0
+    # latent respiration heat loss
+    hl3 = 1.7 * 0.00001 * m * (5867 - pa)
+    # dry respiration heat loss
+    hl4 = 0.0014 * m * (34 - tdb)
+    # heat loss by radiation
+    hl5 = 3.96 * f_cl * (xn**4 - (tra / 100.0) ** 4)
+    # heat loss by convection
+    hl6 = f_cl * hc * (tcl - tdb)
+
+    ts = 0.303 * np.exp(-0.036 * m) + 0.028
+    _pmv = ts * (mw - hl1 - hl2 - hl3 - hl4 - hl5 - hl6)
+
+    return _pmv
+
+#set the test function in air temp to test the pmv_ppd and test do we need to cope with colling effect
+def p_p_o(t_db_x, t_r, v_r, r_h, met, clo_d, pmv_y):
+    
+    solution = _pmv_ppd_optimized(t_db_x, t_r, v_r, r_h, met, clo_d, pmv_y)
+    
+    optimize.brentq(function, 0.0, 40)
+    
+    
+    return solution
+    
+
+def calculate_tdb(t_db_x, t_r, v_r, r_h, met, clo_d, pmv_y):
+    return (
+        _pmv_ppd_optimized(tdb=t_db_x, tr=t_r, vr=v_r, rh=r_h, met=met, clo=clo_d)
+        #p_p_o()
+        - pmv_y
+    )
+
+
+# Psychrometric(air temperature) of ASHRAE
+def psychrometric_ashrae(
+    inputs: dict = None,
+    model: str = "iso",
+    function_selection: str = Functionalities.Default,
+    units: str = "SI",
+    
+):
+    
+    
+    p_tdb = float(inputs[ElementsIDs.t_db_input.value])
+    tr = float(inputs[ElementsIDs.t_r_input.value])
+    vr = float(
+        v_relative(  # Ensure vr is scalar
+            v=inputs[ElementsIDs.v_input.value], met=inputs[ElementsIDs.met_input.value]
+        )
+    )
+    rh = float(inputs[ElementsIDs.rh_input.value])
+    met = float(inputs[ElementsIDs.met_input.value])
+    clo = float(
+        clo_dynamic(  # Ensure clo is scalar
+            clo=inputs[ElementsIDs.clo_input.value],
+            met=inputs[ElementsIDs.met_input.value],
+        )
+    )
+    # save original values for plotting
+    if units == UnitSystem.IP.value:
+        tdb = round(float(units_converter(tdb=p_tdb)[0]), 1)
+        tr = round(float(units_converter(tr=tr)[0]), 1)
+        vr = round(float(units_converter(vr=vr)[0]), 1)
+    else:
+        tdb = p_tdb
+
+    traces = []
+
+    # blue area
+
+    rh_values = np.arange(0, 110, 10)
+    tdb_guess = 22
+    pmv_list = [-0.5, 0.5]
+    tdb_array = np.zeros((len(pmv_list), len(rh_values)))
+    for j, pmv_value in enumerate(pmv_list):
+        for i, rh_value in enumerate(rh_values):
+            solution = fsolve(
+                lambda x: calculate_tdb(
+                    t_db_x=x,
+                    t_r=tr,
+                    v_r=vr,
+                    r_h=rh_value,
+                    met=met,
+                    clo_d=clo,
+                    pmv_y=pmv_value,
+                ),
+                tdb_guess,
+            )
+            tdb_solution = round(solution[0], 1)
+            tdb_guess = tdb_solution
+            tdb_array[j, i] = float(tdb_solution)
+
+    # calculate hr
+    
+    lower_upper_tdb = np.append(tdb_array[0], tdb_array[1][::-1])
+    lower_upper_tdb = [
+        round(float(value), 1) for value in lower_upper_tdb.tolist()
+    ]  # convert to list & round to 1 decimal
+
+    rh_list = np.append(np.arange(0, 110, 10), np.arange(100, -1, -10))
+
+
+    # define
+    lower_upper_hr = []
+    for i in range(len(rh_list)):
+        lower_upper_hr.append(
+            psy_ta_rh(tdb=lower_upper_tdb[i], rh=rh_list[i])["hr"] * 1000
+        )
+
+    lower_upper_hr = [
+        round(float(value), 1) for value in lower_upper_hr
+    ]  # convert to list & round to 1 decimal
+
+    if units == UnitSystem.IP.value:
+        lower_upper_tdb = list(
+            map(
+                lambda x: round(float(units_converter(tmp=x, from_units="si")[0]), 1),
+                lower_upper_tdb,
+            )
+        )
+    
+    # grey area
+    if model == "ashrae" and function_selection == Functionalities.Compare.value:
+            
+            met_2, clo_2, tr_2, t_db_2, v_2, rh_2 = compare_get_inputs(inputs)
+            
+            print("Type of met_2:", type(met_2), "Value:", met_2)
+            print("Type of clo_2:", type(clo_2), "Value:", clo_2)
+            print("Type of tr_2:", type(tr_2), "Value:", tr_2)
+            print("Type of t_db_2:", type(t_db_2), "Value:", t_db_2)
+            print("Type of v_2:", type(v_2), "Value:", v_2)
+            print("Type of rh_2:", type(rh_2), "Value:", rh_2)
+
+            clo_d_compare = clo_dynamic(clo_2, met_2)
+            vr_compare = v_relative(v_2, met_2)
+            
+           
+            vr_2 = vr_compare
+            clo_2 = clo_d_compare
+             # save original values for plotting
+            
+            
+            if units == UnitSystem.IP.value:
+
+                t_db_2 = round(float(units_converter(tdb=t_db_2)[0]), 1)
+                tr_2 = round(float(units_converter(tr=tr_2)[0]), 1)
+                vr_2 = round(float(units_converter(vr=vr_2)[0]), 1)
+                print("Type of t_db_2:", type(t_db_2), "Value:", t_db_2)
+                print("Type of tr_2:", type(tr_2), "Value:", tr_2)
+                print("Type of vr_2:", type(vr_2), "Value:", vr_2)
+               
+            else:
+                t_db_2 = t_db_2
+            
+            
+                
+            print("Type of t_db_2:", type(t_db_2), "Value:", t_db_2)
+            print("Type of tr_2:", type(tr_2), "Value:", tr_2)
+            print("Type of vr_2:", type(vr_2), "Value:", vr_2)
+            
+        
+           
+            traces = []
+    
+    
+            
+            rh_values_2 = np.arange(0, 110, 10)
+            tdb_guess_2 = 22
+            pmv_list_2 = [-0.5, 0.5]
+            tdb_array_2 = np.zeros((len(pmv_list_2), len(rh_values_2)))
+            for j, pmv_value in enumerate(pmv_list_2):
+                for i, rh_value in enumerate(rh_values_2):
+                    solution_2 = fsolve(
+                        lambda x2: calculate_tdb(
+                            t_db_x=x2,
+                            t_r=tr_2,
+                            v_r=vr_2,
+                            r_h=rh_value,
+                            met=met_2,
+                            clo_d=clo_2,
+                            pmv_y=pmv_value,
+                        ),
+                        tdb_guess_2,
+                    )
+                    tdb_solution_2 = round(solution_2[0], 1)
+                    tdb_guess_2 = tdb_solution_2
+                    tdb_array_2[j, i] = float(tdb_solution_2)
+        
+            # calculate hr
+           
+            lower_upper_tdb_2 = np.append(tdb_array_2[0], tdb_array_2[1][::-1])
+            lower_upper_tdb_2 = [
+                round(float(value), 1) for value in lower_upper_tdb_2.tolist()
+            ]  # convert to list & round to 1 decimal
+        
+            rh_list_2 = np.append(np.arange(0, 110, 10), np.arange(100, -1, -10))
+        
+        
+            # define
+            lower_upper_hr_2 = []
+            for i in range(len(rh_list_2)):
+                lower_upper_hr_2.append(
+                    psy_ta_rh(tdb=lower_upper_tdb_2[i], rh=rh_list_2[i])["hr"] * 1000
+                )
+        
+            lower_upper_hr_2 = [
+                round(float(value), 1) for value in lower_upper_hr_2
+            ]  # convert to list & round to 1 decimal
+        
+            if units == UnitSystem.IP.value:
+                lower_upper_tdb_2 = list(
+                    map(
+                        lambda x2: round(float(units_converter(tmp=x2, from_units="si")[0]), 1),
+                        lower_upper_tdb_2,
+                    )
+                )
+        
+            traces.append(
+                go.Scatter(
+                    x=lower_upper_tdb_2,
+                    y=lower_upper_hr_2,
+                    mode="lines",
+                    line=dict(color="rgba(0,0,0,0)"),
+                    fill="toself",
+                    fillcolor="rgba(200, 200, 200, 0.7)",
+                    showlegend=False,
+                    hoverinfo="none",
+                )
+            )
+        
+            # current point
+            # Red point
+        
+            psy_results = psy_ta_rh(t_db_2, rh_2)
+            hr_2 = round(float(psy_results["hr"]) * 1000, 1)
+            t_wb_2 = round(float(psy_results["t_wb"]), 1)
+            t_dp_2 = round(float(psy_results["t_dp"]), 1)
+            h = round(float(psy_results["h"]) / 1000, 1)
+        
+            if units == UnitSystem.IP.value:
+                t_wb_2 = round(float(units_converter(tmp=t_wb_2, from_units="si")[0]), 1)
+                t_dp_2 = round(float(units_converter(tmp=t_dp_2, from_units="si")[0]), 1)
+                h = round(float(h / 2.326), 1)  # kJ/kg => btu/lb
+                t_db_2 = (t_db_2 * 9/5) + 32
+           
+            
+            
+            traces.append(
+                go.Scatter(
+                    x=[t_db_2],
+                    y=[hr_2],
+                    mode="markers",
+                    marker=dict(
+                        color="blue",
+                        size=10,
+                        
+                    ),
+                    
+                    showlegend=False,
+                )
+            )
+
+
+    traces.append(
+        go.Scatter(
+            x=lower_upper_tdb,
+            y=lower_upper_hr,
+            mode="lines",
+            line=dict(color="rgba(0,0,0,0)"),
+            fill="toself",
+            fillcolor="rgba(59, 189, 237, 0.7)",
+            showlegend=False,
+            hoverinfo="none",
+        )
+    )
+
+    # current point
+    # Red point
+
+    psy_results = psy_ta_rh(tdb, rh)
+    hr = round(float(psy_results["hr"]) * 1000, 1)
+    t_wb = round(float(psy_results["t_wb"]), 1)
+    t_dp = round(float(psy_results["t_dp"]), 1)
+    h = round(float(psy_results["h"]) / 1000, 1)
+
+    if units == UnitSystem.IP.value:
+        t_wb = round(float(units_converter(tmp=t_wb, from_units="si")[0]), 1)
+        t_dp = round(float(units_converter(tmp=t_dp, from_units="si")[0]), 1)
+        h =  round(float(h / 2.326), 1)  # kJ/kg => btu/lb
+        tdb = p_tdb
+
+    traces.append(
+        go.Scatter(
+            x=[tdb],
+            y=[hr],
+            mode="markers",
+            marker=dict(
+                color="red",
+                size=10,
+               
+            ),
+            showlegend=False,
+        )
+    )
+
+       
+
+    # lines
+
+    rh_list = np.arange(0, 110, 10, dtype=float).tolist()
+    tdb_list = np.linspace(10, 36, 500, dtype=float).tolist()
+    if units == UnitSystem.IP.value:
+        tdb_list_conv = list(
+            map(
+                lambda x: round(float(units_converter(tmp=x, from_units="si")[0]), 1),
+                tdb_list,
+            )
+        )
+    else:
+        tdb_list_conv = tdb_list
+
+    for rh in rh_list:
+        hr_list = np.array(
+            [psy_ta_rh(tdb=t, rh=rh, p_atm=101325)["hr"] * 1000 for t in tdb_list]
+        )  # kg/kg => g/kg
+        trace = go.Scatter(
+            x=tdb_list_conv,
+            y=hr_list,
+            mode="lines",
+            line=dict(color="grey", width=1),
+            hoverinfo="none",
+            name=f"{rh}% RH",
+            showlegend=False,
+        )
+        traces.append(trace)
+
+    
+    
+    tdb = inputs[ElementsIDs.t_db_input.value]
+    rh = inputs[ElementsIDs.rh_input.value]
+    tr = inputs[ElementsIDs.t_r_input.value]
+
+   
+    
+
+    if units == UnitSystem.SI.value:
+        temperature_unit = "°C"
+        hr_unit = "g<sub>w</sub>/kg<sub>da</sub>"
+        h_unit = "kJ/kg"
         psy_results = psy_ta_rh(tdb, rh)
         t_dp = psy_results.t_dp
         h = psy_results.h/2326
@@ -1783,16 +1932,6 @@ def psy_pmv(
         margin=dict(l=10, t=0),
         height=500,
         width=680,
-=======
-    else:
-        temperature_unit = "°F"
-        hr_unit = "lb<sub>w</sub>/klb<sub>da</sub>"
-        h_unit = "btu/lb"
-
-    # layout
-    layout = go.Layout(
-        hovermode="closest",
->>>>>>> comfort-dash/development
         xaxis=dict(
             title=(
                 "Dry-bulb Temperature [°C]"
@@ -1810,11 +1949,7 @@ def psy_pmv(
             title=(
                 "Humidity Ratio [g<sub>w</sub>/kg<sub>da</sub>]"
                 if units == UnitSystem.SI.value
-<<<<<<< HEAD
                 else "Humidity ratio [lb<sub>w</sub>/klb<sub>da</sub>]"  # 保持角标
-=======
-                else "Humidity ratio [lb<sub>w</sub>/klb<sub>da</sub>]"
->>>>>>> comfort-dash/development
             ),
             range=[0, 30],
             dtick=5,
@@ -1826,9 +1961,8 @@ def psy_pmv(
         ),
         annotations=[
             dict(
-<<<<<<< HEAD
                 x=14 if units == UnitSystem.SI.value else  57,
-                y=28,
+                y=22,
                 xref="x",
                 yref="y",
                 text=(
@@ -1839,44 +1973,17 @@ def psy_pmv(
                     f"tₓwb: {t_wb} {temperature_unit}<br>"
                     f"tₓdp: {t_dp:.1f} {temperature_unit}<br>" 
                     f"h: {h:.2f} {h_unit}<br>"  
-=======
-                x=14 if units == UnitSystem.SI.value else 57.2,
-                y=25,
-                xref="x",
-                yref="y",
-                text=(
-                    f"t<sub>db</sub>: {tdb:.1f} {temperature_unit}<br>"
-                    f"rh: {p_rh:.1f} %<br>"
-                    f"W<sub>a</sub>: {hr} {hr_unit}<br>"
-                    f"t<sub>wb</sub>: {t_wb} {temperature_unit}<br>"
-                    f"t<sub>dp</sub>: {t_dp} {temperature_unit}<br>"
-                    f"h: {h} {h_unit}"
->>>>>>> comfort-dash/development
                 ),
                 showarrow=False,
                 align="left",
                 bgcolor="rgba(255,255,255,0.8)",
                 bordercolor="rgba(0,0,0,0)",
-<<<<<<< HEAD
-                font=dict(size=10),
-=======
                 font=dict(size=14),
->>>>>>> comfort-dash/development
             )
         ],
         showlegend=True,
         plot_bgcolor="white",
-<<<<<<< HEAD
     )
 
     fig = go.Figure(data=traces, layout=layout)
     return fig
-=======
-        margin=dict(l=0, t=10),
-        height=500,
-        width=680,
-    )
-
-    fig = go.Figure(data=traces, layout=layout)
-    return fig
->>>>>>> comfort-dash/development

--- a/components/show_results.py
+++ b/components/show_results.py
@@ -1,7 +1,7 @@
 import dash_mantine_components as dmc
-from pythermalcomfort.models import pmv_ppd, adaptive_ashrae
+from pythermalcomfort.models import pmv_ppd, adaptive_ashrae, set_tmp, adaptive_en, cooling_effect
 from pythermalcomfort.utilities import v_relative, clo_dynamic, mapping
-from pythermalcomfort.models import adaptive_en
+
 from pythermalcomfort.psychrometrics import t_o
 
 from utils.get_inputs import get_inputs
@@ -48,8 +48,67 @@ def display_results(inputs: dict):
             standard=standard,
         )
 
+        # compare- psy-air temp - SET calculation
+        r_set_tmp = set_tmp(
+            tdb=inputs[ElementsIDs.t_db_input.value],
+            tr=inputs[ElementsIDs.t_r_input.value],
+            v=v_relative(
+                v=inputs[ElementsIDs.v_input.value],
+                met=inputs[ElementsIDs.met_input.value],
+            ),
+            rh=inputs[ElementsIDs.rh_input.value],
+            met=inputs[ElementsIDs.met_input.value],
+            clo=clo_dynamic(
+                clo=inputs[ElementsIDs.clo_input.value],
+                met=inputs[ElementsIDs.met_input.value],
+            ),
+            wme=0,
+            limit_inputs=True,
+            units=units,
+            standard=standard,
+
+        )
+        
+        # compare- psy-air temp - cooling_effect calculation
+        r_cooling_effect = cooling_effect(
+            tdb=inputs[ElementsIDs.t_db_input.value],
+            tr=inputs[ElementsIDs.t_r_input.value],
+            vr=v_relative(
+                v=inputs[ElementsIDs.v_input.value],
+                met=inputs[ElementsIDs.met_input.value],
+            ),
+            rh=inputs[ElementsIDs.rh_input.value],
+            met=inputs[ElementsIDs.met_input.value],
+            clo=clo_dynamic(
+                clo=inputs[ElementsIDs.clo_input.value],
+                met=inputs[ElementsIDs.met_input.value],
+            ),
+            wme=0,
+            
+            units=units,
+            
+
+        )
+
+         
+
         # Standard Checker for PMV
         # todo: need to add standard for adaptive methods by ensure if the current red point out of area
+        
+        #define the global variable for the compare- psy air temp return value display.
+        results = []
+        results2 = []
+        results_title = []
+        compliance_text = ""
+        compliance_color = "" 
+        comfort_category = ""
+        compliance_text2 = ""
+        
+        standard_checker = dmc.Text(
+              
+        )
+        
+        
         if selected_model == Models.PMV_ashrae.name:
             if -0.5 <= r_pmv["pmv"] <= 0.5:
                 compliance_text = "✔  Complies with ASHRAE Standard 55-2023"
@@ -110,11 +169,132 @@ def display_results(inputs: dict):
                 dmc.Center(dmc.Text(f"Category: {comfort_category}"))
             )
 
+        # Modify the colour
+        for i in range(1, len(results)):
+            if i == 1 or i == 2:
+                color = (
+                    CompareInputColor.InputColor1.value
+                   
+                )
+                for child in results[i].children:
+                    if isinstance(child, dmc.Center) and isinstance(
+                        child.children, dmc.Text
+                    ):
+                        child.children.style = {"color": color}
+
+        # function selection compare- psy air temp - calculation display on t etop of the graph
+        #set the mark of standard under two  units
         if (
             inputs[ElementsIDs.functionality_selection.value]
             == Functionalities.Compare.value
             and selected_model == Models.PMV_ashrae.name
         ):
+            if -0.5 <= r_pmv["pmv"] <= 0.5:
+                compliance_text = "✔"  
+                compliance_color = "green"
+            else:
+                compliance_text = "✘"
+                compliance_color = "red"
+        else:  # EN
+            if -0.7 <= r_pmv["pmv"] <= 0.7:
+                compliance_text = "✔"
+                compliance_color = "green"
+            else:
+                compliance_text = "✘"
+                compliance_color = "red"
+
+        #set the title based on the two units        
+        if (
+            inputs[ElementsIDs.functionality_selection.value] == Functionalities.Compare.value and selected_model == Models.PMV_ashrae.name
+        ):
+            if units == UnitSystem.SI.value:
+                results_title = [
+                   
+                    dmc.Stack(
+                        children=[
+                            dmc.Center(dmc.Text("Compliance")),
+                            dmc.Center(dmc.Text("PMV")), 
+                            dmc.Center(dmc.Text("PPD")), 
+                            dmc.Center(dmc.Text("Sensation")),
+                            dmc.Center(dmc.Text("SET")),
+                            
+                        ],
+                        gap=5,
+                        style={"textAlign": "left", "width": "100%"},  
+                    ),
+                ]
+            else:
+                results_title = [
+                   
+                    dmc.Stack(
+                        children=[
+                            dmc.Center(dmc.Text("Compliance")),
+                            dmc.Center(dmc.Text("PMV with elevated air speed")), 
+                            dmc.Center(dmc.Text("PPD with elevated air speed")), 
+                            dmc.Center(dmc.Text("Sensation")),
+                            dmc.Center(dmc.Text("SET")),
+                            dmc.Center(dmc.Text("Dry-bulb temp at still air")),
+                            dmc.Center(dmc.Text("Cooling effect")),
+                        ],
+                        gap=5,
+                        style={"textAlign": "left", "width": "100%"},  
+                    ),
+                ]
+            
+           
+            ##set the value of pmv & ppd for column1
+            results = [
+                
+                dmc.Stack(
+                    children=[
+                        dmc.Center(dmc.Text(f"{compliance_text}", style={"color": compliance_color})),
+                        dmc.Center(dmc.Text(f"{r_pmv['pmv']:.2f}")),
+                        dmc.Center(dmc.Text(f"{r_pmv['ppd']:.1f} %")),
+                         
+                    ],
+                    gap=5,
+                    style={"textAlign": "center", "width": "100%"},  
+                ),
+            ]
+           
+            results[0].children.append(
+                dmc.Center(dmc.Text(f"{comfort_category}"))
+            )
+
+            temp_unit = "°F" if units == UnitSystem.IP.value else "°C"
+            if units == UnitSystem.SI.value:
+                
+                results[0].children.append(
+                    dmc.Center(dmc.Text(f"{r_set_tmp:.1f} {temp_unit}"))
+                )
+
+            else:
+                
+                results[0].children.append(
+                    dmc.Center(dmc.Text(f"{r_set_tmp:.1f} {temp_unit}"))
+                )
+                results[0].children.append(
+                    dmc.Center(dmc.Text(f"{inputs[ElementsIDs.t_db_input.value]} {temp_unit}"))
+                )
+                results[0].children.append(
+                    dmc.Center(dmc.Text(f"{r_cooling_effect:.1f} {temp_unit}"))
+                )
+            
+            
+
+            for i in range(0, len(results)):
+                if i == 0:
+                   
+                    color = (
+                        CompareInputColor.InputColor1.value
+                    )
+                    for child in results[i].children[1:]:
+                        if isinstance(child, dmc.Center) and isinstance(
+                            child.children, dmc.Text
+                        ):
+                            child.children.style = {"color": color}
+
+            ##set the value of pmv & ppd for column2
             r_pmv_input2 = pmv_ppd(
                 tdb=inputs[ElementsIDs.t_db_input_input2.value],
                 tr=inputs[ElementsIDs.t_r_input_input2.value],
@@ -134,43 +314,141 @@ def display_results(inputs: dict):
                 standard=standard,
             )
 
-            comfort_category = mapping(
-                r_pmv_input2["pmv"],
-                {
-                    -2.5: "Cold",
-                    -1.5: "Cool",
-                    -0.5: "Slightly Cool",
-                    0.5: "Neutral",
-                    1.5: "Slightly Warm",
-                    2.5: "Warm",
-                    10: "Hot",
-                },
-            )
-            results2 = dmc.SimpleGrid(
-                cols=columns,
-                spacing="xs",
-                verticalSpacing="xs",
-                children=[
-                    dmc.Center(dmc.Text(f"PMV: {r_pmv_input2['pmv']:.2f}")),
-                    dmc.Center(dmc.Text(f"PPD: {r_pmv_input2['ppd']:.1f} %")),
-                    dmc.Center(dmc.Text(f"Sensation: {comfort_category}")),
-                ],
-            )
-            results.append(results2)
+            #set the value of SET for column2
+            r_set_tmp_input2 = set_tmp(
+                tdb=inputs[ElementsIDs.t_db_input_input2.value],
+                tr=inputs[ElementsIDs.t_r_input_input2.value],
+                v=v_relative(
+                    v=inputs[ElementsIDs.v_input_input2.value],
+                    met=inputs[ElementsIDs.met_input_input2.value],
+                ),
+                rh=inputs[ElementsIDs.rh_input_input2.value],
+                met=inputs[ElementsIDs.met_input_input2.value],
+                clo=clo_dynamic(
+                    clo=inputs[ElementsIDs.clo_input_input2.value],
+                    met=inputs[ElementsIDs.met_input_input2.value],
+                ),
+                wme=0,
+                limit_inputs=True,
+                units=units,
+                standard=standard,
 
-            # Modify the colour
-            for i in range(1, len(results)):
-                if i == 1 or i == 2:
+            )
+
+            #set the value of ce for column2
+            r_cooling_effect_input2 = cooling_effect(
+                tdb=inputs[ElementsIDs.t_db_input_input2.value],
+                tr=inputs[ElementsIDs.t_r_input_input2.value],
+                vr=v_relative(
+                    v=inputs[ElementsIDs.v_input_input2.value],
+                    met=inputs[ElementsIDs.met_input_input2.value],
+                ),
+                rh=inputs[ElementsIDs.rh_input_input2.value],
+                met=inputs[ElementsIDs.met_input_input2.value],
+                clo=clo_dynamic(
+                    clo=inputs[ElementsIDs.clo_input_input2.value],
+                    met=inputs[ElementsIDs.met_input_input2.value],
+                ),
+                wme=0,
+               
+                units=units,
+            
+            
+
+            )
+            
+            if (
+            inputs[ElementsIDs.functionality_selection.value] == Functionalities.Compare.value and selected_model == Models.PMV_ashrae.name
+            ):
+                if -0.5 <= r_pmv_input2["pmv"] <= 0.5:
+                    compliance_text2 = "✔"  
+                    compliance_color = "green"
+                else:
+                    compliance_text2 = "✘"
+                    compliance_color = "red"
+            else:  # EN
+                if -0.7 <= r_pmv_input2["pmv"] <= 0.7:
+                    compliance_text2 = "✔"
+                    compliance_color = "green"
+                else:
+                    compliance_text2 = "✘"
+                    compliance_color = "red"
+
+            #arrange the relative display of column2
+            results2 = [
+                
+                dmc.Stack(
+                    children=[
+                        dmc.Center(dmc.Text(f"{compliance_text2}", style={"color": compliance_color})),
+                        dmc.Center(dmc.Text(f"{r_pmv_input2['pmv']:.2f}")),
+                        dmc.Center(dmc.Text(f"{r_pmv_input2['ppd']:.1f} %")),
+                        
+                    ],
+                    gap=5,
+                    style={"textAlign": "right", "width": "50%"}, 
+                ),
+                  
+            ]
+
+            results2[0].children.append(
+                dmc.Center(dmc.Text(f"{comfort_category}"))
+            )
+            
+            temp_unit = "°F" if units == UnitSystem.IP.value else "°C"
+            if units == UnitSystem.SI.value:
+                
+                results2[0].children.append(
+                    dmc.Center(dmc.Text(f"{r_set_tmp_input2:.1f} {temp_unit}"))
+                )
+
+            else:
+                
+                results2[0].children.append(
+                    dmc.Center(dmc.Text(f"{r_set_tmp_input2:.1f} {temp_unit}"))
+                )
+                results2[0].children.append(
+                    dmc.Center(dmc.Text(f"{inputs[ElementsIDs.t_db_input_input2.value]} {temp_unit}"))
+                )
+                results2[0].children.append(
+                    dmc.Center(dmc.Text(f"{r_cooling_effect_input2:.1f} {temp_unit}"))
+                )
+           
+             
+            #add the color  in string in column2
+            for i in range(0, len(results2)):
+                if i == 0:
+                    
                     color = (
-                        CompareInputColor.InputColor1.value
-                        if i == 1
-                        else CompareInputColor.InputColor2.value
+                        CompareInputColor.InputColor2.value
                     )
-                    for child in results[i].children:
+                    for child in results2[i].children[1:]:
                         if isinstance(child, dmc.Center) and isinstance(
                             child.children, dmc.Text
                         ):
                             child.children.style = {"color": color}
+            
+            
+            
+            #arrange the title column1 and column2 onto the same level
+            return dmc.Grid(
+                children=[
+                    dmc.Stack(
+                         children=results_title,
+                         style={"flex": "1", "display": "inline-block"},
+                     ),
+                     dmc.Stack(
+                         children=results,
+                         style={"flex": "1", "display": "inline-block"},
+                     ),
+                     dmc.Stack(
+                         children=results2,
+                         style={"flex": "1", "display": "inline-block"},
+                     ),
+                 ],
+                 style={"display": "flex"},
+            )
+
+                        
 
     elif selected_model == Models.Adaptive_EN.name:
         results = gain_adaptive_en_hover_text(

--- a/pages/home.py
+++ b/pages/home.py
@@ -2,9 +2,7 @@ import dash
 import dash_mantine_components as dmc
 from dash import html, callback, Output, Input, no_update, State, ctx, dcc
 
-<<<<<<< HEAD
-from components.charts import t_rh_pmv, chart_selector, adaptive_en_chart, psychrometric_ashrae
-=======
+
 from components.charts import (
     t_rh_pmv,
     chart_selector,
@@ -12,8 +10,9 @@ from components.charts import (
     SET_outputs_chart,
     adaptive_chart,
     psy_pmv,
+    psychrometric_ashrae,
 )
->>>>>>> comfort-dash/development
+
 from components.dropdowns import (
     model_selection,
 )
@@ -334,7 +333,6 @@ def update_chart(inputs: dict, function_selection: str):
         ]
     )
     image = go.Figure()
-<<<<<<< HEAD
 
      #add 'if' condition to identify whether user want to enter the compare.
     if chart_selected == Charts.psychrometric.value.name:
@@ -357,8 +355,6 @@ def update_chart(inputs: dict, function_selection: str):
             )
 
 
-=======
->>>>>>> comfort-dash/development
     if chart_selected == Charts.t_rh.value.name:
         if (
             selected_model == Models.PMV_EN.name

--- a/pages/home.py
+++ b/pages/home.py
@@ -2,7 +2,7 @@ import dash
 import dash_mantine_components as dmc
 from dash import html, callback, Output, Input, no_update, State, ctx, dcc
 
-from components.charts import t_rh_pmv, chart_selector, adaptive_en_chart
+from components.charts import t_rh_pmv, chart_selector, adaptive_en_chart, psychrometric_ashrae
 from components.dropdowns import (
     model_selection,
 )
@@ -225,6 +225,27 @@ def update_chart(inputs: dict, function_selection: str):
         ]
     )
     image = go.Figure()
+
+     #add 'if' condition to identify whether user want to enter the compare.
+    if chart_selected == Charts.psychrometric.value.name:
+        if (
+            selected_model == Models.PMV_ashrae.name
+            and function_selection == Functionalities.Compare.value
+        ):
+            image = psychrometric_ashrae(
+                inputs=inputs,
+                model="ashrae",
+                function_selection=function_selection,
+                units=units,
+            )
+
+            image = psychrometric_ashrae(
+                inputs=inputs,
+                model="ashrae",
+                function_selection=function_selection,
+                units=units,
+            )
+
 
     if chart_selected == Charts.t_rh.value.name:
         if (


### PR DESCRIPTION
The chart and annotation including the si and ip modes can be displayed correctly. The filled area (blue and grey) and red point(input1) with purple point(input2) can be moved based on the user selection on those six attributes.



- [ ]  added "psychrometric air temperature" charts into the compare of function selection in the project, and combined 'PMV-ASHREA' and 'PMV EN' into one function to simplify the code into the compare of function selection in the project.

 

- [ ] The attributes including 'Relative humidity', 'Dry-bulb Temperature' and comfort level can be shown in the compare of function selection

- [ ]  There are two filled areas blue and grey that are on input 1 and 2 respectively.

- [ ]  If one of the points is outside the comfort area, the warning "not comply with the one standard" can be shown on the chart.

 

- [ ] The relevant exchanges including x-axis, input box, and the returned value on the top of the chart can be displayed on two modes 'si' and 'ip'

 

- [ ] The relevant value in Annotation can be shown on the two modes 'si' and 'ip'

- [ ] The string value of "complies with ASHRAE Standard 55-2023" can be adjusted by user changing the input of temperature or comfort area:

unit test:
User can select "compare" selection functionality and then choose the psychrometric air temperature, and set inputs of air temperature, mean radiant temperature, air speed, relative humidity, metabolic rate (met)and clothing level (clo). The chart will generate the visualization. The annotation will be generated and change the value based on the current mouse position. The chart size adapts to the current UI interface.
![1](https://github.com/user-attachments/assets/1d3b244b-12db-4222-bbe6-4efa4b1e0d68)


Can manually select SI or IP unit:
![3](https://github.com/user-attachments/assets/2a2a4edb-25e5-455d-aa81-583fea7153bc)


When the red dot inside the neutral sensation region and the blue dot outside the neutral sensation region, the corresponding ‘✔’(comply with ASHRAE Standard 55-2023），’✘‘ (Does not comply with ASHRAE Standard 55-2023), and both of their sensation will be displayed above the show result.
pic (SI or IP unit:)
![2](https://github.com/user-attachments/assets/41bc5b28-c299-4a3c-a87e-e2543f9361d7)
![2 ip](https://github.com/user-attachments/assets/f000666d-400d-47a5-a71d-fb3d70a4d4f6)



Likewise, the blue dot inside the neutral sensation region and the red dot outside the neutral sensation region, the corresponding ‘✔’(comply with ASHRAE Standard 55-2023），’✘‘ (Does not comply with ASHRAE Standard 55-2023), and both of their sensation will be displayed above the show result. will be displayed above the show result.
pic (SI or IP unit:)
![2 倒](https://github.com/user-attachments/assets/789e6289-e210-4c4c-b54f-b76064ecafa0)
![2 ip 倒](https://github.com/user-attachments/assets/3ebb6a48-17e5-494d-8558-3d12df5c4891)



The column names are changed if the units changing from SI and IP
![4](https://github.com/user-attachments/assets/2c5a9b82-6037-401a-aa09-70508ce64879)
