### PR TITLE
Chart change units should not move

### DIFF
--- a/components/charts.py
+++ b/components/charts.py
@@ -83,9 +83,9 @@ def adaptive_chart(
     traces = []
 
     if units == UnitSystem.IP.value:
-        x_values = np.array([50, 92.3]) if model == "iso" else np.array([50, 92.3])
+        x_values = np.array([50, 92.3])
     else:
-        x_values = np.array([10, 30]) if model == "iso" else np.array([10, 33.5])
+        x_values = np.array([10, 33.5])
 
     if model == "iso":
         adaptive_func = adaptive_en
@@ -170,7 +170,7 @@ def adaptive_chart(
                 if units == UnitSystem.SI.value
                 else "Prevailing Mean Outdoor Temperature [°F]"
             ),
-            range=[10, 30] if model == "iso" else [10, 33.5],
+            range=[10, 33.5],
             dtick=2 if units == UnitSystem.SI.value else 5,
             showgrid=True,
             gridcolor="lightgray",
@@ -186,7 +186,7 @@ def adaptive_chart(
                 if units == UnitSystem.SI.value
                 else "Operative Temperature [°F]"
             ),
-            range=[14, 36] if units == UnitSystem.SI.value else [60, 104],
+            range=[14, 36] if units == UnitSystem.SI.value else [57.2, 97.6],
             dtick=2 if units == UnitSystem.SI.value else 5,
             showgrid=True,
             gridcolor="lightgray",
@@ -678,7 +678,7 @@ def t_rh_pmv(
                 if units == UnitSystem.SI.value
                 else "Dry-bulb Temperature [°F]"
             ),
-            range=[10, 36] if units == UnitSystem.SI.value else [50, 100],
+            range=[10, 36] if units == UnitSystem.SI.value else [50, 96.8],
             dtick=2 if units == UnitSystem.SI.value else 5,
         ),
         showlegend=False,

--- a/components/charts.py
+++ b/components/charts.py
@@ -1673,7 +1673,7 @@ def speed_temp_pmv(
         height=500,
         width=680,
         xaxis=dict(
-            range=[20, 34] if units == UnitSystem.SI.value else [68, 94],  # x range
+            range=[20, 34] if units == UnitSystem.SI.value else [68, 93.2],  # x range
             tickmode="linear",
             tick0=20 if units == UnitSystem.SI.value else 65,
             dtick=2 if units == UnitSystem.SI.value else 2,

--- a/components/show_results.py
+++ b/components/show_results.py
@@ -429,6 +429,7 @@ def display_results(inputs: dict):
             trm=inputs[ElementsIDs.t_rm_input.value],
             v=inputs[ElementsIDs.v_input.value],
             units=units,
+            model=Models.Adaptive_EN,
         )
 
     elif selected_model == Models.Adaptive_ASHRAE.name:
@@ -438,6 +439,7 @@ def display_results(inputs: dict):
             trm=inputs[ElementsIDs.t_rm_input.value],
             v=inputs[ElementsIDs.v_input.value],
             units=units,
+            model=Models.Adaptive_ASHRAE,
         )
 
     if selected_model == Models.PMV_ashrae.name:


### PR DESCRIPTION
# Adaptive EN, Adaptive Ashrae, PMV - EN, PMV-Ashrae charts bug fixing
Fixed the issue where the chart's content position remained unchanged when converting the X and Y axes from Celsius to Fahrenheit. Ensured that the data in the chart stays in the correct position after changing the unit of the axes.
## Type of change
- [x] Bug fixing

Make sure the chart in correct position after change the unit of axes in Adaptive EN
![image](https://github.com/user-attachments/assets/17f23a7c-00e0-47b1-bf58-b091d47d4197)
![image](https://github.com/user-attachments/assets/af8654a8-9adc-4477-83a5-5498a2bc3eef)


Make sure the chart in correct position after change the unit of axes in Adaptive Ashrae
![image](https://github.com/user-attachments/assets/447e0047-d22c-448b-8011-ab5812ab7c6c)
![image](https://github.com/user-attachments/assets/8306434a-f1a3-4c04-abc6-29621416c6a9)

Make sure the chart in correct position after change the unit of axes in PMV Ashrae
![image](https://github.com/user-attachments/assets/bf939dc3-5ffe-4110-8d33-0cebe4e3058f)
![image](https://github.com/user-attachments/assets/db080f4c-bc4e-43e3-be52-bb62995dfe4f)



## Checklist

- [x] The code has been formatted via black

